### PR TITLE
メルカリなどのSPAで動的にtitleが変わる場合に対応

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,47 +1,60 @@
-let msg = document.title;
+const textOffsetPixel = 14;
 
-/// set up style of page title indicator
-let indicator = document.createElement('div');
-indicator.style.position = 'fixed';
-indicator.style.bottom = 0;
-indicator.style.right = 0;
-indicator.style.zIndex = 999;
+const mtt = () => {
+  let msg = document.title;
 
-indicator.style.backgroundColor = 'white';
-indicator.style.border = '1px solid #000';
-indicator.style.height = '25px';
-indicator.style.width = '100px';
-indicator.style.paddingLeft = '4px';
+  /// set up style of page title indicator
+  let indicator = document.createElement('div');
+  indicator.style.position = 'fixed';
+  indicator.style.bottom = 0;
+  indicator.style.right = 0;
+  indicator.style.zIndex = 999;
 
-/*
-indicator.addEventListener('mouseover', (ev)=>{
-  let elm = ev.target;
-  elm.style.opacity = 0;
-});
-indicator.addEventListener('mouseout', (ev)=>{
-  let elm = ev.target;
-  elm.style.opacity = 100;
-});
-*/
+  indicator.style.color = 'black';
+  indicator.style.backgroundColor = 'white';
+  indicator.style.border = '1px solid #000';
+  indicator.style.height = '25px';
+  indicator.style.width = '100px';
+  indicator.style.paddingLeft = '4px';
 
-/// Hide on double click
-indicator.addEventListener('dblclick', (ev)=>{
-  let elm = ev.target;
-  elm.style.display = 'none';
-});
-document.body.appendChild(indicator);
+  /// Hide on double click
+  indicator.addEventListener('dblclick', (ev)=>{
+    let elm = ev.target;
+    elm.style.display = 'none';
+  });
+  document.body.appendChild(indicator);
+
+  indicator.style.width = (calcTitleWidth() + textOffsetPixel) + 'px';
+  indicator.id = 'pageTitleIndicator';
+  indicator.textContent = msg;
+}
+
+const timeout = window.setTimeout(mtt, 1000);
+
+const watchTitleTag = () => {
+  const target = document.querySelector('title');
+  const observer = new MutationObserver((mutations) => {
+    const title = mutations[0].target.textContent;
+    document.querySelector('#pageTitleIndicator').textContent = title;
+    document.querySelector('#pageTitleIndicator').style.width = (calcTitleWidth() + textOffsetPixel) + 'px';
+  });
+  const config = { subtree: true, characterData: true, childList: true };
+  observer.observe(target, config);
+}
+
+const timeout2 = window.setTimeout(watchTitleTag, 1200);
 
 /// treat multi-byte characters length with box
-let tmpElm = document.createElement('span');
-tmpElm.style.visibility = 'hidden';
-tmpElm.style.whiteSpace = 'pre';
-tmpElm.textContent = msg;
-document.body.appendChild(tmpElm);
-
-const width = tmpElm.offsetWidth;
-document.body.removeChild(tmpElm);
-let offsetPx = 14;
-indicator.style.width = (width + offsetPx) + 'px';
-indicator.textContent = msg;
+const calcTitleWidth = () => {
+  const msg = document.title;
+  const tmpElm = document.createElement('span');
+  tmpElm.style.visibility = 'hidden';
+  tmpElm.style.whiteSpace = 'pre';
+  tmpElm.textContent = msg;
+  document.body.appendChild(tmpElm);
+  const width = tmpElm.offsetWidth;
+  document.body.removeChild(tmpElm);
+  return width;
+}
 
 /// end of code


### PR DESCRIPTION
* メルカリでは、一部のページにおいてURLが変わっているのにonloadイベントが発生していない。
* つまり、SPAである。
* このアドオンはonload時に動作するので、タイトルの変更に追従できない。
* [TITLEタグのonchangeイベントは無いので、MutationObserverを使う必要](https://stackoverflow.com/questions/2497200/how-to-listen-for-changes-to-the-title-element)があった。